### PR TITLE
HTMLCanvasElement.toBlob() が使えるのならば使う

### DIFF
--- a/angular/src/app/album/album.component.ts
+++ b/angular/src/app/album/album.component.ts
@@ -308,16 +308,22 @@ export class AlbumComponent implements OnInit {
     }
     ctx.drawImage(img, 0, 0);
     const type = 'image/jpeg';
-    const dataURL = canvas.toDataURL(type);
-    const bin = atob(dataURL.split(',')[1]);
-    // 空の Uint8Array ビューを作る
-    const buffer = new Uint8Array(bin.length);
-    // Uint8Array ビューに 1 バイトずつ値を埋める
-    for (let i = 0; i < bin.length; i++) {
-      buffer[i] = bin.charCodeAt(i);
-    }
-    // Uint8Array ビューのバッファーを抜き出し、それを元に Blob を作る
-    const blob = new Blob([buffer.buffer as ArrayBuffer], {type: type});
+    const blob = await new Promise<Blob>(resolve => {
+      if (canvas.toBlob) {
+        canvas.toBlob(blob => resolve(blob), type);
+      } else {
+        const dataURL = canvas.toDataURL(type);
+        const bin = atob(dataURL.split(',')[1]);
+        // 空の Uint8Array ビューを作る
+        const buffer = new Uint8Array(bin.length);
+        // Uint8Array ビューに 1 バイトずつ値を埋める
+        for (let i = 0; i < bin.length; i++) {
+          buffer[i] = bin.charCodeAt(i);
+        }
+        // Uint8Array ビューのバッファーを抜き出し、それを元に Blob を作る
+        resolve(new Blob([buffer.buffer as ArrayBuffer], {type: type}));
+      }
+    });
     return URL.createObjectURL(blob);
   }
 }


### PR DESCRIPTION
一般的なブラウザでは canvas から blob に直接変換できるメソッドが用意されています。
この PR では、可能ならばそのメソッドを使用することによって表示処理を高速化します。

https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob

iOS の safari ではこのメソッドに対応していませんが、Android の chrome では使えるため、
この PR の変更によって特に廉価で低スペックな Android 端末での処理改善が期待されます。