### PR TITLE
optimize: image-orientation: from-image に対応しているならば回転処理を CSS に任せる

### DIFF
--- a/angular/src/app/album/album.component.sass
+++ b/angular/src/app/album/album.component.sass
@@ -7,3 +7,4 @@
   row-gap: 1rem
   img
     width: 300px
+    image-orientation: from-image


### PR DESCRIPTION
[image-orientation - CSS: Cascading Style Sheets | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/image-orientation)

`image-orientation: from-image` に対応しているのならば、ブラウザ側での回転処理に任せる変更です。回転処理をネイティブで実行するため処理が高速になります。加えて、後述のブラウザの挙動の変更に伴う不正動作対策のパッチでもあります。

[JPEG images are now rotated by default according to Exif data \(Breaking\) | Firefox Site Compatibility](https://www.fxsitecompat.dev/en-CA/docs/2020/jpeg-images-are-now-rotated-by-default-according-to-exif-data/)

この変更により画像の向きは Exif データを参照して Firefox 側で自動回転するのが標準になりました。これは非互換性を伴う変更であって、事実このアプリにも影響を与えます。すなわち、回転処理が Firefox 内部と本アプリの 2 回実施されるため、画像が不正に表示されます。

![wrong_rotated](https://user-images.githubusercontent.com/379009/83982190-8c5b4380-a95f-11ea-8e68-c71072240393.jpg)

`image-orientation: from-image` で明示的にブラウザ側で画像回転を指示することで、ブラウザの標準動作の変更の影響をなくして、正しく動作させることが出来ます。
