### PR TITLE
日本語のアルバム名に対応 #83

### DIFF
--- a/src/app/[...slug]/album.tsx
+++ b/src/app/[...slug]/album.tsx
@@ -11,7 +11,7 @@ import JSZip from "jszip";
 import FileSaver from "file-saver"
 
 export default function Album({ params }: { params: { slug: string[] } }) {
-  const album_id = params.slug[0];
+  const album_id = params.slug[0] && decodeURIComponent(params.slug[0]);
   const photo_id = params.slug[1];
 
   const readQueue = useRef(new JobQueue('read'));

--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -4,7 +4,7 @@ import Album from "./album"
 // メタデータを生成する
 export async function generateMetadata({ params }: { params: { slug: string[] } }): Promise<Metadata> {
     return {
-        title: params.slug[0],
+        title: params.slug[0] && decodeURIComponent(params.slug[0]),
     } as Metadata;
 }
 


### PR DESCRIPTION
fix #83

### 概要

このPull Requestは、##83 で報告されたURIデコードの問題を対応します。

### 変更点

**`[...slug]/album.tsx`および`[...slug]/page.tsx`でのURIデコード**:
    - slugパラメータからのアルバムIDとタイトルが正しくURIデコードされるようにしました。

### テスト

これらの変更を適用した後、アルバムIDに日本語が使用した場合に正常に動作するか確認してください。

